### PR TITLE
Add news-driven fundamentals trading pipeline skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
-# Hello-World
--
+# NSE News & Fundamentals Trading System
+
+This repository implements a local, zero‑cost pipeline for Indian equities. It
+collects annual reports and daily India‑focused news, filters them with
+`gpt-4o-mini`, and backtests a simple VWAP strategy.
+
+## Layout
+
+```
+repo/
+ ├─ data/                # cached PDFs, raw news, prices
+ ├─ pipelines/
+ │    ├─ fetch_reports.py
+ │    ├─ fetch_news.py
+ │    ├─ gpt_filter.py
+ │    └─ backtest.py
+ ├─ config.py            # API keys, paths, constants
+ ├─ requirements.txt
+ └─ README.md
+```
+
+## Quick start
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+export OPENAI_API_KEY="..."
+python pipelines/fetch_reports.py --ticker TCS
+python pipelines/fetch_news.py --ticker TCS --company "Tata Consultancy Services"
+python pipelines/gpt_filter.py --ticker TCS --company "Tata Consultancy Services"
+python pipelines/backtest.py --ticker TCS --company "Tata Consultancy Services"
+```
+
+The outputs are written under `data/<ticker>/` as `reports.json`, daily news
+JSONs, `signals.parquet`, `trades.csv`, and `performance.html`.

--- a/config.py
+++ b/config.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import os
+
+# Base directories
+BASE_DIR = Path(__file__).resolve().parent
+DATA_DIR = BASE_DIR / "data"
+PIPELINE_DIR = BASE_DIR / "pipelines"
+
+# OpenAI configuration
+OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
+
+# Trading constants
+POSITION_SIZE = 0.05  # 5% of equity per position
+TAKE_PROFIT = 0.15
+STOP_LOSS = -0.10
+MAX_HOLD_DAYS = 10
+COOL_OFF_DAYS = 5
+
+# Misc
+DATE_FORMAT = "%Y-%m-%d"

--- a/pipelines/backtest.py
+++ b/pipelines/backtest.py
@@ -1,0 +1,120 @@
+"""Backtest simple news-driven strategy."""
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timedelta
+
+import pandas as pd
+import yfinance as yf
+import empyrical as emp
+
+from config import (
+    DATA_DIR,
+    POSITION_SIZE,
+    TAKE_PROFIT,
+    STOP_LOSS,
+    MAX_HOLD_DAYS,
+    COOL_OFF_DAYS,
+)
+
+
+def load_signals(ticker: str) -> pd.DataFrame:
+    path = DATA_DIR / ticker / "signals.parquet"
+    if path.exists():
+        df = pd.read_parquet(path)
+        df["date"] = pd.to_datetime(df["date"])
+        df = df[df["impact"] == "POS"]
+        df = df[df["relevance"] == 1]
+        return df
+    return pd.DataFrame(columns=["date", "url", "impact", "relevance", "rationale"])
+
+
+def load_prices(ticker: str) -> pd.DataFrame:
+    end = datetime.utcnow()
+    start = end - timedelta(days=365 * 5)
+    df = yf.download(ticker, start=start, end=end, progress=False)
+    df.index = pd.to_datetime(df.index)
+    df["typical"] = (df["High"] + df["Low"] + df["Close"]) / 3.0
+    df["200dma"] = df["Close"].rolling(200).mean()
+    return df
+
+
+def backtest(ticker: str, signals: pd.DataFrame, prices: pd.DataFrame) -> pd.DataFrame:
+    trades = []
+    position = None
+    cool_off = 0
+
+    for date, row in prices.iterrows():
+        if position:
+            # check exit
+            hold_days = (date - position["entry_date"]).days
+            ret = (row["Close"] - position["entry_price"]) / position["entry_price"]
+            if ret >= TAKE_PROFIT:
+                trades.append({**position, "exit_date": date, "exit_price": row["Close"], "reason": "tp"})
+                position = None
+                cool_off = COOL_OFF_DAYS
+            elif ret <= STOP_LOSS:
+                trades.append({**position, "exit_date": date, "exit_price": row["Close"], "reason": "sl"})
+                position = None
+                cool_off = COOL_OFF_DAYS
+            elif hold_days >= MAX_HOLD_DAYS:
+                trades.append({**position, "exit_date": date, "exit_price": row["Close"], "reason": "time"})
+                position = None
+                cool_off = COOL_OFF_DAYS
+        else:
+            if cool_off > 0:
+                cool_off -= 1
+                continue
+            signal_today = signals[signals["date"] == date]
+            if not signal_today.empty and row["Close"] > row["200dma"]:
+                # enter next day's VWAP (approx typical price of next day)
+                next_idx = prices.index.get_loc(date) + 1
+                if next_idx < len(prices):
+                    next_row = prices.iloc[next_idx]
+                    entry_price = next_row["typical"]
+                    position = {"entry_date": prices.index[next_idx], "entry_price": entry_price}
+
+    # close open position at end
+    if position:
+        last_row = prices.iloc[-1]
+        trades.append({**position, "exit_date": prices.index[-1], "exit_price": last_row["Close"], "reason": "eod"})
+
+    return pd.DataFrame(trades)
+
+
+def evaluate(trades: pd.DataFrame, prices: pd.DataFrame) -> pd.DataFrame:
+    if trades.empty:
+        return pd.DataFrame()
+    equity = 1.0
+    curve = []
+    for _, t in trades.iterrows():
+        ret = (t["exit_price"] - t["entry_price"]) / t["entry_price"]
+        equity *= 1 + POSITION_SIZE * ret
+        curve.append({"date": t["exit_date"], "equity": equity})
+    curve_df = pd.DataFrame(curve).set_index("date")
+    returns = curve_df["equity"].pct_change().dropna()
+    metrics = {
+        "CAGR": emp.annual_return(returns),
+        "Sharpe": emp.sharpe_ratio(returns),
+        "MaxDrawdown": emp.max_drawdown(returns.cumsum()),
+    }
+    return pd.DataFrame(metrics, index=[0])
+
+
+def run_backtest(ticker: str) -> None:
+    signals = load_signals(ticker)
+    prices = load_prices(ticker)
+    trades = backtest(ticker, signals, prices)
+    out_dir = DATA_DIR / ticker
+    out_dir.mkdir(exist_ok=True)
+    trades.to_csv(out_dir / "trades.csv", index=False)
+    perf = evaluate(trades, prices)
+    perf.to_html(out_dir / "performance.html", index=False)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ticker", required=True)
+    parser.add_argument("--company", required=True)
+    args = parser.parse_args()
+    run_backtest(args.ticker)

--- a/pipelines/fetch_news.py
+++ b/pipelines/fetch_news.py
@@ -1,0 +1,122 @@
+"""Fetch daily news for an NSE ticker from Google News and GDELT."""
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import List, Dict
+
+import feedparser
+import requests
+from newspaper import Article
+import trafilatura
+from prefect import flow, task
+
+from config import DATA_DIR, DATE_FORMAT
+
+HEADERS = {"User-Agent": "Mozilla/5.0"}
+
+
+def _scrape(url: str) -> str:
+    """Download and clean article text."""
+    try:
+        art = Article(url)
+        art.download()
+        art.parse()
+        return art.text
+    except Exception:
+        downloaded = trafilatura.fetch_url(url)
+        if downloaded:
+            return trafilatura.extract(downloaded, include_comments=False, include_tables=False) or ""
+    return ""
+
+
+def _hash_url(url: str) -> str:
+    return hashlib.sha256(url.encode()).hexdigest()
+
+
+@task
+def fetch_google_news(ticker: str, company_name: str) -> List[Dict]:
+    query = f"{company_name} OR {ticker} site:in"
+    url = (
+        "https://news.google.com/rss/search?q="
+        + requests.utils.quote(query)
+        + "&hl=en-IN&gl=IN&ceid=IN:en"
+    )
+    feed = feedparser.parse(url)
+    articles: List[Dict] = []
+    for entry in feed.entries:
+        link = entry.link
+        articles.append(
+            {
+                "title": entry.title,
+                "url": link,
+                "published": entry.published,
+                "source": getattr(entry, "source", {}).get("title"),
+                "text": _scrape(link),
+                "hash": _hash_url(link),
+            }
+        )
+    return articles
+
+
+@task
+def fetch_gdelt(ticker: str, company_name: str) -> List[Dict]:
+    query = requests.utils.quote(f'"{company_name}" OR {ticker}')
+    url = (
+        "https://api.gdeltproject.org/api/v2/doc/doc?query="
+        + query
+        + "&mode=ArtList&format=json&maxrecords=50&sort=DateDesc"
+    )
+    resp = requests.get(url, headers=HEADERS, timeout=30)
+    resp.raise_for_status()
+    data = resp.json()
+    articles: List[Dict] = []
+    for doc in data.get("articles", []):
+        link = doc["url"]
+        articles.append(
+            {
+                "title": doc.get("title"),
+                "url": link,
+                "published": doc.get("seendate"),
+                "source": doc.get("sourceCommonName"),
+                "text": _scrape(link),
+                "hash": _hash_url(link),
+            }
+        )
+    return articles
+
+
+@task
+def save_news(ticker: str, articles: List[Dict]) -> Path:
+    date_str = datetime.utcnow().strftime(DATE_FORMAT)
+    out_dir = DATA_DIR / ticker / "news"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_file = out_dir / f"{date_str}.json"
+    with out_file.open("w") as f:
+        json.dump(articles, f, indent=2)
+    return out_file
+
+
+@flow
+def fetch_news(ticker: str, company_name: str) -> Path:
+    google_articles = fetch_google_news(ticker, company_name)
+    gdelt_articles = fetch_gdelt(ticker, company_name)
+    seen = set()
+    deduped: List[Dict] = []
+    for art in google_articles + gdelt_articles:
+        if art["hash"] not in seen:
+            seen.add(art["hash"])
+            deduped.append(art)
+    return save_news(ticker, deduped)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ticker", required=True)
+    parser.add_argument("--company", required=True, help="Full company name")
+    args = parser.parse_args()
+    fetch_news(args.ticker, args.company)

--- a/pipelines/fetch_reports.py
+++ b/pipelines/fetch_reports.py
@@ -1,0 +1,62 @@
+"""Download and parse annual reports/fundamentals for an NSE ticker."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict
+
+import requests
+from prefect import flow, task
+
+from config import DATA_DIR
+
+HEADERS = {"User-Agent": "Mozilla/5.0"}
+
+
+@task
+def fetch_fundamentals(ticker: str) -> Dict[str, Dict[str, float]]:
+    """Fetch last three fiscal years of key fundamentals from Screener API."""
+    url = f"https://www.screener.in/api/company/{ticker}/"
+    resp = requests.get(url, headers=HEADERS, timeout=30)
+    resp.raise_for_status()
+    data = resp.json()
+    # Structure: data['data']['financials']['Profit & Loss']['yearly']
+    pl = data["data"]["financials"]["Profit & Loss"]["yearly"]
+    bs = data["data"]["financials"]["Balance Sheet"]["yearly"]
+
+    years = sorted(pl.keys())[-3:]  # last 3 fiscal years
+    metrics: Dict[str, Dict[str, float]] = {}
+    for year in years:
+        metrics[year] = {
+            "revenue": pl[year].get("Sales"),
+            "ebitda": pl[year].get("Operating Profit"),
+            "pat": pl[year].get("Net Profit"),
+            "debt": bs[year].get("Borrowings"),
+            "cash": bs[year].get("Cash & Bank"),
+        }
+    return metrics
+
+
+@task
+def save_reports(ticker: str, metrics: Dict[str, Dict[str, float]]) -> Path:
+    out_dir = DATA_DIR / ticker
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_file = out_dir / "reports.json"
+    with out_file.open("w") as f:
+        json.dump(metrics, f, indent=2)
+    return out_file
+
+
+@flow
+def fetch_reports(ticker: str) -> Path:
+    metrics = fetch_fundamentals(ticker)
+    return save_reports(ticker, metrics)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ticker", required=True)
+    args = parser.parse_args()
+    fetch_reports(args.ticker)

--- a/pipelines/gpt_filter.py
+++ b/pipelines/gpt_filter.py
@@ -1,0 +1,99 @@
+"""Classify scraped news using GPT-4o-mini."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List, Dict
+
+import pandas as pd
+from openai import OpenAI
+from prefect import flow, task
+
+from config import DATA_DIR, OPENAI_API_KEY, OPENAI_MODEL
+
+
+@task
+def load_fundamentals(ticker: str) -> Dict:
+    path = DATA_DIR / ticker / "reports.json"
+    with path.open() as f:
+        return json.load(f)
+
+
+@task
+def load_news_files(ticker: str) -> List[Path]:
+    news_dir = DATA_DIR / ticker / "news"
+    return sorted(news_dir.glob("*.json"))
+
+
+@task
+def classify_file(ticker: str, company: str, fundamentals: Dict, news_file: Path) -> pd.DataFrame:
+    with news_file.open() as f:
+        articles = json.load(f)
+    if not articles:
+        return pd.DataFrame()
+
+    client = OpenAI(api_key=OPENAI_API_KEY)
+    system_prompt = (
+        "You are an equity-research analyst. Using the latest FY fundamentals: "
+        + json.dumps(fundamentals)
+        + "\nFor each article provided, output JSON list objects:\n"
+        '{"relevance":0|1, "impact":"POS|NEG|NEU", "rationale":"25 words"}\n'
+        "– relevance=1 only if the piece unambiguously refers to the company.\n"
+        "– impact is POS if earnings or financing terms should improve in next 12 months; NEG if worsen."
+    )
+    messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": json.dumps(articles)},
+    ]
+    resp = client.chat.completions.create(model=OPENAI_MODEL, messages=messages)
+    content = resp.choices[0].message.content
+    try:
+        classifications = json.loads(content)
+    except Exception:
+        # if parsing fails, mark all irrelevant
+        classifications = [
+            {"relevance": 0, "impact": "NEU", "rationale": "parse error"}
+            for _ in articles
+        ]
+
+    rows = []
+    for art, cls in zip(articles, classifications):
+        rows.append(
+            {
+                "date": news_file.stem,
+                "url": art["url"],
+                "impact": cls.get("impact"),
+                "relevance": cls.get("relevance"),
+                "rationale": cls.get("rationale"),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+@task
+def save_signals(ticker: str, df: pd.DataFrame) -> Path:
+    out_file = DATA_DIR / ticker / "signals.parquet"
+    if out_file.exists():
+        old = pd.read_parquet(out_file)
+        df = pd.concat([old, df], ignore_index=True)
+    df.to_parquet(out_file, index=False)
+    return out_file
+
+
+@flow
+def gpt_filter(ticker: str, company: str) -> Path:
+    fundamentals = load_fundamentals(ticker)
+    files = load_news_files(ticker)
+    dfs = [classify_file(ticker, company, fundamentals, f) for f in files]
+    df = pd.concat(dfs, ignore_index=True) if dfs else pd.DataFrame()
+    return save_signals(ticker, df)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ticker", required=True)
+    parser.add_argument("--company", required=True)
+    args = parser.parse_args()
+    gpt_filter(args.ticker, args.company)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+prefect==2.*
+cloudscraper
+requests
+tabula-py
+camelot-py
+feedparser
+newspaper3k
+trafilatura
+yfinance
+duckdb
+empyrical
+pandas
+numpy
+openai

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,12 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from config import POSITION_SIZE, TAKE_PROFIT, STOP_LOSS
+
+
+def test_risk_parameters():
+    assert 0 < POSITION_SIZE < 1
+    assert TAKE_PROFIT > 0
+    assert STOP_LOSS < 0


### PR DESCRIPTION
## Summary
- scaffold local trading pipeline with Prefect flows for fetching fundamentals, news, LLM filtering, and VWAP backtesting
- provide configuration module and requirements for open-source data and GPT-4o-mini integration
- document quick-start usage in README and add basic config unit test

## Testing
- `pytest -q`
- `python -m py_compile $(find . -name '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6896483ef640832588e14416563f00ff